### PR TITLE
#6 アプリバージョンを更新するGitHub Actions の追加

### DIFF
--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -1,0 +1,56 @@
+name: Update app version
+
+on:
+  workflow_dispatch:
+    inputs:
+      versionMajor:
+        description: 'バージョン情報: major'
+        required: true
+        type: string
+      versionMinor:
+        description: 'バージョン情報: minor'
+        required: true
+        type: string
+      versionPatch:
+        description: 'バージョン情報: patch'
+        required: true
+        type: string
+
+jobs:
+  update-app-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      # https://github.com/actions/checkout
+      - uses: actions/checkout@v4
+
+      # https://github.com/ruby/setup-ruby
+      - uses: ruby/setup-ruby@v1
+
+      - name: Update app version
+        id: app-version
+        run: |
+          ruby scripts/set-version.rb ${{ inputs.versionMajor }} ${{ inputs.versionMinor }} ${{ inputs.versionPatch }}
+          echo "$(ruby scripts/pick-version-name.rb)" > TMP_LOG
+          echo "version-name=$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup git settings
+        run: |
+          git config --local user.email "github.actions@example.com"
+          git config --local user.name "GitHub Actions"
+          echo "Finish setup git"
+
+      - name: Git push
+        run: |
+          git switch -c "feature/${{ steps.app-version.outputs.version-name }}"
+          git add Build.xcconfig
+          git commit -m "Update app version ${{ steps.app-version.outputs.version-name }}"
+          git push origin
+          echo "Updated git"
+
+      - name: Create pull request
+        run: gh pr create --title "Update app version ${{ steps.app-version.outputs.version-name }}" --body ""
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
* [x] 新規追加

## 概要
GitHub 上でアプリバージョン更新し、
Pull Request を生成出来るようにしました。



## 変更点
### 追加
* GitHub Actions の追加



## 確認事項
下記の制約があるので、ある程度動作確認が取れたらマージして、GitHub Actions を試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.

※リポジトリ設定の `Actions > General >Workflow permissions` で `Allow GitHub Actions to create and approve pull requests` を有効にしてください。



## 備考
* [GitHub Actions から Pull Request を作成する](https://zenn.dev/fujimotoshinji/scraps/8c78d4afca6f14)
* [GitHub ActionsでのPR操作権限はデフォルトでオフになったよ](https://zenn.dev/kenghaya/articles/d7f766e5db6437)
* [GitHub Actionsのpermissionを粛々と整理した話 - 10X Product Blog](https://product.10x.co.jp/entry/2023/10/18/170930)
* [ワークフローのトリガー - GitHub Docs](https://docs.github.com/ja/actions/using-workflows/triggering-a-workflow#defining-inputs-for-manually-triggered-workflows)
