### PR TITLE
#6 アプリバージョンを更新するGitHub Actions の調整

### DIFF
--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -34,21 +34,20 @@ jobs:
         run: |
           ruby scripts/set-version.rb ${{ inputs.versionMajor }} ${{ inputs.versionMinor }} ${{ inputs.versionPatch }}
           echo "$(ruby scripts/pick-version-name.rb)" > TMP_LOG
+          echo "branch-name=feature/update_$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
           echo "version-name=$(cat TMP_LOG)" >> "$GITHUB_OUTPUT"
 
       - name: Setup git settings
         run: |
           git config --local user.email "github.actions@example.com"
           git config --local user.name "GitHub Actions"
-          echo "Finish setup git"
 
       - name: Git push
         run: |
-          git switch -c "feature/${{ steps.app-version.outputs.version-name }}"
+          git switch -c ${{ steps.app-version.outputs.branch-name }}
           git add Build.xcconfig
-          git commit -m "Update app version ${{ steps.app-version.outputs.version-name }}"
-          git push origin
-          echo "Updated git"
+          git commit -m "Update ${{ steps.app-version.outputs.version-name }}"
+          git push --set-upstream origin ${{ steps.app-version.outputs.branch-name }}
 
       - name: Create pull request
         run: gh pr create --title "Update app version ${{ steps.app-version.outputs.version-name }}" --body ""


### PR DESCRIPTION
* [x] 既存改良

## 概要
GitHub Actions "update-app-version" で下記のエラーが出たので、その修正を行った。

``` log
Run git switch -c "feature/0.0.1"
Switched to a new branch 'feature/0.0.1'
[feature/0.0.1 6fe0140] Update app version 0.0.1
 1 file changed, 1 insertion(+), 1 deletion(-)
fatal: The current branch feature/0.0.1 has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin feature/0.0.1

To have this happen automatically for branches without a tracking
upstream, see 'push.autoSetupRemote' in 'git help config'.

Error: Process completed with exit code 128.
```



## 変更点
### 修正
* 不具合の修正



## 確認事項
下記の制約があるので、ある程度動作確認が取れたらマージして、GitHub Actions を試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.



## 備考
特になし
