### PR TITLE
#6 設定の調整

### DIFF
--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Setup git settings
         run: |
-          git config --local user.email "github.actions@example.com"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "GitHub Actions"
 
       - name: Git push

--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -50,6 +50,6 @@ jobs:
           git push --set-upstream origin ${{ steps.app-version.outputs.branch-name }}
 
       - name: Create pull request
-        run: gh pr create --title "Update app version ${{ steps.app-version.outputs.version-name }}" --body ""
+        run: 'gh pr create --title "アプリバージョン更新: ${{ steps.app-version.outputs.version-name }}" --body ""'
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
* [x] 既存改良

## 概要
下記を調整しました。

* Git ユーザーをGitHub Actions と同じものに変更
* コミットログをAndroid 版と同じものに変更
    * 例: https://github.com/tshion/yumemi-inc_android-engineer-codecheck/commit/c6db943590d6f0baeba3c1cfa17c9f57092d0b7f



## 変更点
### 修正
* 概要に記載した内容



## 確認事項
下記の制約があるので、ある程度動作確認が取れたらマージして、GitHub Actions を試してみてください。

> To trigger the workflow_dispatch event, your workflow must be in the default branch.



## 備考
* [GitHub Actions上でgit commitするときにgit userをどうするか #GitHubActions - Qiita](https://qiita.com/thaim/items/3d1a4d09ec4a7d8844ce)
    * https://github.com/actions/checkout/issues/13
